### PR TITLE
Add new webhook commands

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -4,6 +4,7 @@ import spoilerAttachments from './spoiler-attachments';
 import autoThreadInvite from './auto-thread-invite';
 import rawMessage from './raw-message';
 import messageFilter from './message-filter';
+import { simple as mod, full as modhook } from './modhook';
 import { Command } from './commands';
 import logger from './logger';
 
@@ -27,7 +28,7 @@ interface Module {
   additionalHandlers?: Partial<{ [K in keyof ClientEvents]: (client: Client, ...args: ClientEvents[K]) => Awaitable<void> }>;
 }
 
-const modules: Module[] = [autoPublish, spoilerAttachments, autoThreadInvite, rawMessage, messageFilter];
+const modules: Module[] = [autoPublish, spoilerAttachments, autoThreadInvite, rawMessage, messageFilter, mod, modhook];
 const commands = modules.reduce<{ [name: string]: Command }>(
   (acc, module) => {
     if (module.command === undefined) {

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -7,6 +7,14 @@ if (token === undefined) {
   process.exit(1);
 }
 
+const guildTextChannelTypes = [
+  'GUILD_TEXT' as const,
+  'GUILD_NEWS' as const,
+  'GUILD_NEWS_THREAD' as const,
+  'GUILD_PRIVATE_THREAD' as const,
+  'GUILD_PUBLIC_THREAD' as const,
+];
+
 const filterTypes: ApplicationCommandOptionChoice[] = [
   {
     name: 'Matches any message that contains the filter content verbatim',
@@ -284,12 +292,104 @@ const cmds: ApplicationCommandDataResolvable[] = [
         ]
       }
     ]
-  }
+  },
+  {
+    type: 'CHAT_INPUT',
+    name: 'mod',
+    description: 'Send a message in a more official-looking way',
+    options: [
+      {
+        type: 'STRING',
+        name: 'content',
+        description: 'Content of the message to send',
+        required: true
+      },
+      {
+        type: 'STRING',
+        name: 'edit-link',
+        description: 'If provided, will edit the message at the given link rather than sending a new one',
+        required: false
+      },
+      {
+        type: 'CHANNEL',
+        name: 'channel',
+        description: 'If provided, will send in the specified channel instead of this one',
+        required: false,
+        channelTypes: guildTextChannelTypes
+      },
+      //{
+      //  type: 'ATTACHMENT',
+      //  name: 'attachment',
+      //  description: 'Optional attachment to include',
+      //  required: false
+      //},
+    ],
+    defaultPermission: false
+  },
+  {
+    type: 'CHAT_INPUT',
+    name: 'webhook',
+    description: 'Send and edit webhook messages',
+    options: [
+      {
+        type: 'STRING',
+        name: 'content',
+        description: 'Content of the message to send. Prefix with `RAW:` to interpret the rest of the string as raw JSON.',
+        required: true
+      },
+      {
+        type: 'STRING',
+        name: 'edit-link',
+        description: '(Incompat. with appearance + destination opts) Link to message to edit rather than sending a new one',
+        required: false
+      },
+      {
+        type: 'CHANNEL',
+        name: 'channel',
+        description: 'If provided, will send in the specified channel instead of this one',
+        required: false,
+        channelTypes: guildTextChannelTypes
+      },
+      //{
+      //  type: 'ATTACHMENT',
+      //  name: 'attachment',
+      //  description: 'Optional attachment to include',
+      //  required: false
+      //},
+      {
+        type: 'STRING',
+        name: 'webhook-id',
+        description: 'Alternate webhook to use instead of the default one.',
+        required: false
+      },
+      {
+        type: 'STRING',
+        name: 'username',
+        description: 'Alternate username to post with instead of the webhook\'s default',
+        required: false
+      },
+      {
+        type: 'STRING',
+        name: 'avatar-link',
+        description: 'Alternate avatar to post with instead of the webhook\'s default. Lower priority than `avatar`.',
+        required: false
+      },
+      //{
+      //  type: 'ATTACHMENT',
+      //  name: 'avatar',
+      //  description: 'Alternate avatar to post with instead of the webhook\'s default. Higher priority than `avatar-link`.',
+      //  required: false
+      //},
+    ],
+    defaultPermission: false
+  },
 ];
 
 const client = new Client({ intents: [] });
 client.once('ready', async () => {
-  await client.application.commands.set(cmds);
+  const guildId = process.env.HARMONY_DEPLOY_GUILD;
+  if (guildId) await (await client.guilds.fetch(guildId)).commands.set(cmds);
+  else await client.application.commands.set(cmds);
   console.log('All commands deployed');
   client.destroy();
 });

--- a/src/modhook.ts
+++ b/src/modhook.ts
@@ -1,0 +1,114 @@
+import { Client, CommandInteraction, GuildTextBasedChannel, MessageOptions, NewsChannel, TextChannel, Webhook } from 'discord.js';
+import { SimpleCommand } from './commands';
+import logger from './logger';
+import { MessageResolveError, patterns, resolveMessageLink } from './message-utils';
+import { guilds as storage } from './storage';
+
+async function getWebhook(channel: TextChannel | NewsChannel): Promise<Webhook> {
+  const guildId = channel.guildId;
+  const channelId = channel.id;
+  const client = channel.client;
+
+  storage.channels(guildId);
+  const stored: string = storage.channels(guildId).get(channelId, 'webhook');
+  if (stored) return client.fetchWebhook(stored);
+  else {
+    const webhook = await channel.createWebhook(channel.guild.name, {
+      avatar: channel.guild.iconURL(),
+      reason: 'Harmony mod message sending'
+    });
+    storage.channels(guildId).set(channelId, 'webhook', webhook.id);
+    return webhook;
+  }
+}
+
+const handlers = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async send(client: Client, interaction: CommandInteraction): Promise<any> {
+    await interaction.deferReply({ ephemeral: true });
+    const content = interaction.options.getString('content', true);
+
+    const editLink = interaction.options.getString('edit-link');
+    const webhookArg = interaction.options.getString('webhook-id');
+    const channel = interaction.options.getChannel('channel');
+    if ((editLink && webhookArg) || (editLink && channel) || (webhookArg && channel)) {
+      return await interaction.editReply('Destination-setting options cannot be used alongside each other.');
+    }
+    const webhookId = (webhookArg) ? patterns.webhook.match(webhookArg).groups?.webhookId ?? null : undefined;
+    if (webhookId === null) return await interaction.editReply('`webhook-id` does not point to a valid webhook!');
+
+    let message;
+    if (editLink) try {
+      message = await resolveMessageLink(client, editLink, { asUser: interaction.user });
+      if (!message.webhookId || message.guildId !== interaction.guildId) throw new MessageResolveError('');
+    } catch (e) {
+      if (e instanceof MessageResolveError) {
+        return await interaction.editReply('`edit-link` does not point to a valid message!');
+      } else throw e;
+    }
+
+    const webhook = editLink
+      ? await message.fetchWebhook()
+      : webhookId
+        ? await interaction.client.fetchWebhook(webhookId)
+        : await getWebhook((channel ?? interaction.channel) as TextChannel);
+
+    if (webhook.type === 'Channel Follower') return await interaction.editReply('Cannot use channel follower webhooks.');
+
+    //const attachment = interaction.options.getAttachment('attachment');
+    //const avatarImg = interaction.options.getAttachment('avatar');
+
+    const parsed: MessageOptions = (content.startsWith('RAW:{'))
+      ? JSON.parse(content.replace('RAW:', ''))
+      : { content: content.replaceAll('   ', '\n') };
+
+    logger.info({
+      message: `Sending message from ${interaction.user.tag}`,
+      context: {
+        sourceChannel: `#${(interaction.channel as GuildTextBasedChannel).name}`,
+        sentChannel: webhook.channelId,
+        guild: interaction.guildId,
+        webhook: webhook.url,
+        editLink,
+      }
+    });
+
+    const username = interaction.options.getString('username');
+    const avatarURL = /*avatarImg?.url??*/ interaction.options.getString('avatar-link');
+    if (editLink) {
+      if (avatarURL || username) return await interaction.editReply('`edit-link` cannot be used alongside appearance options.');
+      else await webhook.editMessage(message, parsed);
+    } else {
+      await webhook.send({
+        ...parsed,
+        username: username ?? interaction.guild.name,
+        avatarURL: avatarURL ?? interaction.guild.iconURL(),
+        //attachments: [attachment],
+      });
+    }
+
+    await interaction.editReply('Sent!');
+  }
+};
+
+/**
+ * Easy-to-use variant of the command. Should accept only two options: `content` (required) and `edit-link` (optional).
+ */
+export const simple = {
+  command: new SimpleCommand(
+    'mod',
+    handlers.send
+  )
+};
+
+/**
+ * Full version of the command, which is far more flexible but far more complicated.
+ * 
+ * Note: Only difference here is the name, deploy metadata is where the main differences are.
+ */
+export const full = {
+  command: new SimpleCommand(
+    'webhook',
+    handlers.send
+  )
+};


### PR DESCRIPTION
Adds two commands: `mod`, which exposes just a couple options (channel and edit link) to avoid option fatigue, and `webhook`, which exposes a fuller set (channel, edit link, username, avatar URL, webhook link/ID). (They use the same handlers, just a difference in what the metadata says it accepts.)

There's also a bit of commented-out code to prep for attachments support once the option type drops, but obviously can't be tested yet.

Advanced feature if you want to play around with it: starting the message content with the string `RAW:` will tell it to interpret the rest of it as raw message JSON, so you can do embeds and stuff that way.